### PR TITLE
Fixed how the spoonacular api call parses through the data

### DIFF
--- a/src/main/java/data_access/FindInstructionsSpoonacular.java
+++ b/src/main/java/data_access/FindInstructionsSpoonacular.java
@@ -55,13 +55,20 @@ public class FindInstructionsSpoonacular {
                 return steps;
             }
 
+            int stepNumber = 1;
             for (int i = 0; i < stepArray.length(); i++) {
                 JSONObject stepObj = stepArray.getJSONObject(i);
-                int number = stepObj.optInt("number", i + 1);
                 String stepText = stepObj.optString("step", "").trim();
 
                 if (!stepText.isEmpty()) {
-                    steps.add(new InstructionStep(number, stepText));
+                    // Split by: period/!/? followed by space + capital OR capital letter after lowercase (missing punctuation)
+                    String[] sentences = stepText.split("(?<=[.!?])\\s*(?=[A-Z])");
+                    for (String sentence : sentences) {
+                        String trimmed = sentence.trim();
+                        if (!trimmed.isEmpty()) {
+                            steps.add(new InstructionStep(stepNumber++, trimmed));
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
**Overview**
Fixed an issue in FindInstructionsSpoonacular where the API returned abnormally long instruction steps that were difficult to read. The parser now splits steps into individual sentences for better readability.

**Files Modified**
FindInstructionsSpoonacular.java

**Problem**
The Spoonacular API sometimes returns very long instruction steps that combine multiple sentences into a single step. For example:
Mix the wet ingredients, warm the liquid either in the microwave (about 40 seconds) or on the stovetop you want the temperature to be that of a hot bath.Slowly incorporate the liquid into the dry ingredients while stirring.When you can stir no more, start to knead the dough with your hands.

**Solution**
Modified the parsing logic to split steps by sentences using regex pattern matching:
Splits on periods, exclamation marks, or question marks followed by a capital letter
Handles edge cases where punctuation is missing (e.g., "bath.Slowly" with no space)
Uses \s* to match zero or more spaces after punctuation


**Testing**
Manually tested with recipes containing long multi-sentence steps. Confirmed proper splitting at sentence boundaries.